### PR TITLE
Add postcss-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
         "style-loader": "^0.19.0",
         "tailwindcss": "^0.2.2",
         "webpack": "^3.8.1"
+    },
+    "dependencies": {
+        "postcss-import": "^11.0.0"
     }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
     plugins: [
+        require('postcss-import')(),
         require('tailwindcss')('./tailwind.js')
     ]
 }


### PR DESCRIPTION
The problem you're facing is that all of your `@import` statements are being processed as regular, plain old CSS imports, which means they are remaining in your output and not actually being inlined into one file like how a Sass or Less import works.

This PR adds the `postcss-import` plugin which will process all of your `@import` statements and inline the imported files, much like how importing works with a preprocessor.

Once all of the imports are processed and everything is inlined into one file, `@apply` will work properly because now it can actually see the class you're trying to apply 👍 